### PR TITLE
ci: add release workflow for SDK publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,52 @@
+name: Release SDKs
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish-js:
+    name: Publish JavaScript SDK
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/js-v')
+    defaults:
+      run:
+        working-directory: sdks/js
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm test
+      - run: npm run build
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-python:
+    name: Publish Python SDK
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/py-v')
+    defaults:
+      run:
+        working-directory: sdks/python
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install build tools
+        run: pip install build twine
+      - name: Run tests
+        run: |
+          pip install -e ".[dev]"
+          pytest
+      - name: Build package
+        run: python -m build
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI }}
+        run: twine upload dist/*


### PR DESCRIPTION
- Publish JS SDK to npm on js-v* tags
- Publish Python SDK to PyPI on py-v* tags
- Runs tests before publishing