### PR TITLE
feat: add multi-modal content support to middleware and registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,3 +50,42 @@ jobs:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI }}
         run: twine upload dist/*
+
+  publish-express-middleware:
+    name: Publish Express Middleware
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/middleware-v')
+    defaults:
+      run:
+        working-directory: implementations/express-middleware
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm test
+      - run: npm run build
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-registry:
+    name: Publish Registry CLI
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/registry-v')
+    defaults:
+      run:
+        working-directory: tools/registry
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm run build
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/tools/registry/package.json
+++ b/tools/registry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@goreal-ai/plp-registry",
-  "version": "0.0.3",
+  "version": "1.0.0",
   "description": "PLP Registry CLI - Manage PLP server registration, compliance testing, and listing on plp.pub",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tools/registry/src/types.ts
+++ b/tools/registry/src/types.ts
@@ -48,9 +48,28 @@ export interface TestContext {
   debug?: boolean;
 }
 
+// Multi-modal content types
+export interface TextContent {
+  type: 'text';
+  text: string;
+}
+
+export interface ImageUrl {
+  url: string;
+  detail?: 'auto' | 'low' | 'high';
+}
+
+export interface ImageContent {
+  type: 'image_url';
+  image_url: ImageUrl;
+}
+
+export type ContentPart = TextContent | ImageContent;
+export type PromptContent = string | ContentPart[];
+
 export interface PromptEnvelope {
   id: string;
-  content: string;
+  content: PromptContent;
   meta: Record<string, unknown>;
 }
 


### PR DESCRIPTION
## Summary
Add multi-modal content support to Express middleware and Registry CLI to align with PLP v1.1.0.

## Changes

### Express Middleware (`@goreal-ai/plp-express-middleware`)
- Add `ContentPart` types (`TextContent`, `ImageContent`)
- Update `PromptEnvelope` to accept `string | ContentPart[]`
- Add `isValidContent()` validation function
- Fully backward compatible with string content

### Registry CLI (`@goreal-ai/plp-registry`)
- Add multi-modal types to `types.ts`
- Update compliance tests to accept both string and array content
- Bump version from 0.0.3 → 1.0.0

### Release Workflow
- Add `middleware-v*` tag trigger for Express middleware
- Add `registry-v*` tag trigger for Registry CLI

## Release Tags
After merge, create releases with:
- `middleware-v1.0.0` → publishes `@goreal-ai/plp-express-middleware`
- `registry-v1.0.0` → publishes `@goreal-ai/plp-registry`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)